### PR TITLE
Fix side panel overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -998,11 +998,8 @@
         const sidePanelContent = document.getElementById('sidePanelContent');
         const sidePanelClose = document.getElementById('sidePanelClose');
         
-        // オーバーレイ要素を動的に作成
-        const sidePanelOverlay = document.createElement('div');
-        sidePanelOverlay.className = 'side-panel-overlay';
-        sidePanelOverlay.id = 'sidePanelOverlay';
-        document.body.appendChild(sidePanelOverlay);
+        // サイドパネルのオーバーレイ要素を取得
+        const sidePanelOverlay = document.getElementById('sidePanelOverlay');
 
         // --- ヘルプ説明文 ---
         const helpTexts = {
@@ -1964,6 +1961,7 @@
             `;
             
             sidePanel.classList.add('open');
+            sidePanelOverlay.classList.add('open');
         }
 
         function generateInsights(range, winRate, avgProfit, trades) {
@@ -2015,6 +2013,7 @@
 
         function closeSidePanel() {
             sidePanel.classList.remove('open');
+            sidePanelOverlay.classList.remove('open');
         }
 
         function resetAnalysisView(keepFilters = false) {


### PR DESCRIPTION
## Summary
- Remove duplicate dynamic creation of side panel overlay and reuse existing DOM element.
- Toggle overlay visibility alongside side panel open/close actions.

## Testing
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_68aaaab51044832389331bfe7dffe995